### PR TITLE
Moved to pete module, Syscalls are now working

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -34,17 +34,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "atty"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
-dependencies = [
- "hermit-abi 0.1.19",
- "libc",
- "winapi",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -63,21 +52,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "327762f6e5a765692301e5bb513e0d9fef63be86bbc14528052b1cd3e6f03e07"
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "cc"
-version = "1.0.82"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "305fe645edc1442a0fa8b6726ba61d422798d37a52e12eaecf4b022ebbb88f01"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -197,15 +183,25 @@ checksum = "7fcaabb2fef8c910e7f4c7ce9f67a1283a1715879a7c230ca9d6d1ae31f16d91"
 
 [[package]]
 name = "env_logger"
-version = "0.7.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
 dependencies = [
- "atty",
  "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
+]
+
+[[package]]
+name = "errno"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+dependencies = [
+ "libc",
+ "windows-sys",
 ]
 
 [[package]]
@@ -240,26 +236,25 @@ dependencies = [
 
 [[package]]
 name = "hermit-abi"
-version = "0.1.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
-dependencies = [
- "libc",
-]
-
-[[package]]
-name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
 name = "humantime"
-version = "1.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
 dependencies = [
- "quick-error",
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -298,6 +293,7 @@ dependencies = [
  "config",
  "log",
  "nix",
+ "pete",
  "pretty_env_logger",
  "syscalls",
  "sysinfo",
@@ -309,6 +305,12 @@ name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "log"
@@ -327,6 +329,15 @@ name = "memoffset"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "memoffset"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d61c719bcfbcf5d62b3a09efa6088de8c54bc0bfcd3ea7ae39fcc186108b8de1"
 dependencies = [
  "autocfg",
 ]
@@ -352,7 +363,7 @@ version = "0.26.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "cfg-if",
  "libc",
  "memoffset 0.7.1",
@@ -385,7 +396,7 @@ version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.3.2",
+ "hermit-abi",
  "libc",
 ]
 
@@ -404,12 +415,6 @@ dependencies = [
  "dlv-list",
  "hashbrown",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pathdiff"
@@ -462,6 +467,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "pete"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f09c1c1ad40df294ff8643fe88a3dc64fff3293b6bc0ed9f71aff71f7086cbd"
+dependencies = [
+ "libc",
+ "memoffset 0.8.0",
+ "nix",
+ "thiserror",
+]
+
+[[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -469,9 +486,9 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pretty_env_logger"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+checksum = "865724d4dbe39d9f3dd3b52b88d859d66bcb2d6a0acfd5ea68a65fb66d4bdc1c"
 dependencies = [
  "env_logger",
  "log",
@@ -485,12 +502,6 @@ checksum = "18fb31db3f9bddb2ea821cde30a9f70117e3f119938b5ee630b7403aa6e2ead9"
 dependencies = [
  "unicode-ident",
 ]
-
-[[package]]
-name = "quick-error"
-version = "1.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quote"
@@ -559,7 +570,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88073939a61e5b7680558e6be56b419e208420c2adb92be54921fa6b72283f1a"
 dependencies = [
  "base64",
- "bitflags",
+ "bitflags 1.3.2",
  "serde",
 ]
 
@@ -571,6 +582,19 @@ checksum = "f6d5f2436026b4f6e79dc829837d467cc7e9a55ee40e750d716713540715a2df"
 dependencies = [
  "cfg-if",
  "ordered-multimap",
+]
+
+[[package]]
+name = "rustix"
+version = "0.38.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+dependencies = [
+ "bitflags 2.4.1",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -617,6 +641,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_repr"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3081f5ffbb02284dda55132aa26daecedd7372a42417bbbab6f14ab7d6bb9145"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -646,12 +681,12 @@ dependencies = [
 
 [[package]]
 name = "syscalls"
-version = "0.4.2"
+version = "0.6.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd12358646fffc4806f82248a9eca6690da845c1717f7c8d017c85a24868f1b3"
+checksum = "56b389b38331a454883a34fd19f25cbd1510b3510ff7aa28cb8d6de85d888439"
 dependencies = [
- "cc",
- "paste",
+ "serde",
+ "serde_repr",
 ]
 
 [[package]]
@@ -767,6 +802,72 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "yaml-rust"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,12 +9,8 @@ edition = "2021"
 config = "0.13.3"
 log = "0.4.17"
 nix = "0.26.2"
-pretty_env_logger = "0.4.0"
-syscalls = "0.4.2"
+pretty_env_logger = "0.5.0"
+syscalls = "0.6.15"
 sysinfo = "0.29.0"
-thiserror = "1.0.44"
-
-[profile.release]
-strip = true
-opt-level = "z"
-lto = true
+thiserror = "1.0.11"
+pete = "0.12.0"

--- a/config.toml
+++ b/config.toml
@@ -1,2 +1,2 @@
-process_name = "tcpdump"
+process_name = "top"
 log_level_filter = "trace"

--- a/src/debugee.rs
+++ b/src/debugee.rs
@@ -1,5 +1,6 @@
-use std::{ffi::c_void, process::exit};
+use std::{ffi::c_void, mem, process::exit};
 
+use crate::utils::get_pid_from_process_name;
 use log::{self};
 use nix::{
     libc::user_regs_struct,
@@ -9,13 +10,11 @@ use nix::{
         wait::{waitpid, WaitStatus},
     },
 };
-use sysinfo::{PidExt, ProcessExt, System, SystemExt};
+use pete::{Ptracer, Tracee};
 use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum DebugeeErr {
-    #[error("Process not found `{0}`")]
-    ProcessNotFound(String),
     #[error("Nix Error `{0}`")]
     NixError(#[from] nix::errno::Errno),
     #[error("Unexpected Wait Status `{0:#?}`")]
@@ -26,36 +25,59 @@ pub enum DebugeeErr {
     MmapBadAddress(u64),
     #[error("Munmap Error `{0:#?}`")]
     MunmapFailed(u64),
+    #[error("Pete Error: `{0:#?}`")]
+    PeteError(#[from] pete::Error),
 }
 
 pub type DebugeeResult<T> = Result<T, DebugeeErr>;
 pub struct Debugee {
     pub pid: nix::unistd::Pid,
     pub process_name: String,
+    pub tracee: Option<Tracee>,
     is_attached: bool,
 }
 
 impl Debugee {
     pub fn new(process_name: String) -> Self {
-        let dbg: Debugee = Debugee {
-            pid: get_pid_from_process_name(process_name.as_str()),
+        let pid = get_pid_from_process_name(process_name.as_str());
+        let debugee: Debugee = Debugee {
+            pid,
             process_name,
+            tracee: None,
             is_attached: false,
         };
-        dbg
+        debugee
+    }
+
+    fn get_tracee(&self) -> Tracee {
+        if let Some(tracee) = self.tracee {
+            tracee.to_owned()
+        } else {
+            log::error!("Problem obtaining tracee");
+            exit(-1);
+        }
     }
 
     pub fn attach(&mut self) {
-        ptrace::attach(self.pid).unwrap_or_else(|error| {
-            log::error!("Failed attaching to process, error: {}", error);
-            exit(-1);
-        });
-        self.is_attached = true;
-        log::info!("Successfuly attached pid {}", self.pid);
+        let mut ptracer = Ptracer::new();
+        let _ = ptracer.attach(self.pid);
+
+        match ptracer.wait() {
+            Ok(tracee) => {
+                log::info!("Successfuly attached pid {}", self.pid);
+                self.is_attached = true;
+                self.tracee = tracee;
+                tracee
+            }
+            _ => {
+                log::error!("Failed attaching to process");
+                exit(-1)
+            }
+        };
     }
 
     pub fn detach(&mut self) {
-        if (self.is_attached) {
+        if self.is_attached {
             // Detach with ptrace
             match ptrace::detach(self.pid, Signal::SIGCONT) {
                 Ok(()) => {
@@ -89,24 +111,26 @@ impl Debugee {
     }
 
     // Wrapping ptrace write
-    fn write(&self, addr: *mut c_void, data: *mut c_void) -> DebugeeResult<()> {
-        log::trace!("writing to address: {:#?}", addr);
-        unsafe { ptrace::write(self.pid, addr, data).map_err(DebugeeErr::NixError) }
+    pub fn write(&mut self, addr: u64, data: &[u8]) -> DebugeeResult<usize> {
+        self.get_tracee()
+            .write_memory(addr, data)
+            .map_err(DebugeeErr::PeteError)
     }
 
     // Wrapping ptrace read
-    fn read(&self, addr: *mut c_void) -> DebugeeResult<i64> {
-        log::trace!("reading from address: {:#?}", addr);
-        ptrace::read(self.pid, addr).map_err(DebugeeErr::NixError)
+    pub fn read(&self, addr: u64, len: usize) -> DebugeeResult<Vec<u8>> {
+        self.get_tracee()
+            .read_memory(addr, len)
+            .map_err(DebugeeErr::PeteError)
     }
 
     pub fn syscall(
-        &self,
+        &mut self,
         syscall: syscalls::Sysno,
         rdi: u64,
         rsi: u64,
         rdx: u64,
-        rcx: u64,
+        r10: u64,
         r8: u64,
         r9: u64,
     ) -> DebugeeResult<user_regs_struct> {
@@ -114,16 +138,18 @@ impl Debugee {
             log::error!("There is no debugee attached");
             exit(-1);
         }
-
-        let backup_registers = ptrace::getregs(self.pid)?;
+        let syscall_name = syscall.name();
+        let syscall_number = syscall.id();
+        let backup_registers = self.get_tracee().registers()?;
 
         // In order to syscall, we need to set RIP to a SYSCALL gadget
-        let original_rip = backup_registers.rip as *mut c_void;
-        let original_rip_opcodes = self.read(original_rip)? as *mut c_void;
+        let original_rip = backup_registers.rip;
+        let original_rip_opcodes = self.read(original_rip, mem::size_of::<u64>())?;
 
         // Write our syscall opcode to RIP
-        let syscall_opcode = u16::from_le_bytes([0x0F, 0x05]) as *mut c_void;
-        self.write(original_rip, syscall_opcode)?;
+        // let syscall_opcode = u16::from_le_bytes([0x0F, 0x05]);
+        let syscall_opcode: &[u8] = &[0x0F, 0x05];
+        self.write(original_rip, &syscall_opcode)?;
 
         // Provide registers for the syscall
         let mut new_registers = backup_registers;
@@ -131,7 +157,7 @@ impl Debugee {
         new_registers.rdi = rdi;
         new_registers.rsi = rsi;
         new_registers.rdx = rdx;
-        new_registers.rcx = rcx;
+        new_registers.r10 = r10;
         new_registers.r8 = r8;
         new_registers.r9 = r9;
 
@@ -140,13 +166,16 @@ impl Debugee {
         });
 
         log::info!("Successfuly changed syscall opcode and registers");
+        log::trace!(
+            "Executing `{syscall_name}`({syscall_number}) with: {rdi}, {rsi}, {rdx}, {r10}, {r8}, {r9}"
+        );
         self.single_step()?;
-
         let result = ptrace::getregs(self.pid)?;
 
         // Restore original instructions, and original registers to continue normal program control flow
-        self.write(original_rip, original_rip_opcodes)?;
-        ptrace::setregs(self.pid, backup_registers)?;
+        self.write(original_rip, &original_rip_opcodes)?;
+
+        self.get_tracee().set_registers(backup_registers)?;
         log::info!("Restored opcodes and registers");
 
         log::info!("Syscall return value: {:#?}", result.rax as *mut c_void);
@@ -162,30 +191,4 @@ impl Drop for Debugee {
             self.detach();
         }
     }
-}
-
-fn get_pid_from_process_name(process_name: &str) -> nix::unistd::Pid {
-    let system = System::new_all();
-    let process_instances = system
-        .processes_by_exact_name(process_name)
-        .take(2)
-        .collect::<Vec<_>>();
-
-    // Verify there's only one
-    match process_instances.len() {
-        0 => {
-            log::error!("Process not found!");
-            exit(-1)
-        }
-        2 => {
-            log::error!("Found more than 1 process for the given name!");
-            exit(-1)
-        }
-        _ => {} // Gets here if there's 1 - should continue executing
-    }
-
-    let process = process_instances[0];
-    log::info!("Found '{}' with pid: {}", process.name(), process.pid());
-    let pid_u32 = PidExt::as_u32(process.pid());
-    nix::unistd::Pid::from_raw(pid_u32 as i32)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,12 @@
 use log::{self};
+use syscalls::Sysno;
 
 mod debugee;
 mod utils;
 
-use debugee::{Debugee, DebugeeResult};
+use crate::debugee::Debugee;
+use debugee::DebugeeResult;
 use nix::libc::{MAP_ANONYMOUS, MAP_PRIVATE, PROT_READ, PROT_WRITE};
-use syscalls::Sysno;
 fn main() -> DebugeeResult<()> {
     // Read config file
     let injector_config = utils::read_config("config");
@@ -16,25 +17,29 @@ fn main() -> DebugeeResult<()> {
         .init();
 
     log::trace!(
-        "built config with: process_name: '{}', log_level_filter: {}",
-        injector_config.process_name,
-        injector_config.log_level_filter
+        "built config with: process_name: '{}'",
+        injector_config.process_name
     );
 
     let mut debugee = Debugee::new(injector_config.process_name);
     debugee.attach();
-    let mem_address = debugee.syscall(
-        Sysno::mmap,
-        0,
-        10,
-        (PROT_READ | PROT_WRITE) as u64,
-        (MAP_PRIVATE | MAP_ANONYMOUS) as u64,
-        u64::MAX,
-        0,
-    )?;
+    let _mem_address = debugee
+        .syscall(
+            Sysno::mmap,
+            0,                                    // start
+            11,                                   // len
+            (PROT_READ | PROT_WRITE) as u64,      // prot
+            (MAP_PRIVATE | MAP_ANONYMOUS) as u64, // flags
+            0,                                    // fd
+            0,                                    // offset
+        )
+        .unwrap()
+        .rax;
 
-    // let mem_address = debugee.syscall(Sysno::exit, 42, 0, 0, 0, 0, 0)?;
-    debugee.detach();
-
+    debugee.write(_mem_address, &[1, 2, 3, 4, 5])?;
+    let mem = debugee.read(_mem_address, 11)?;
+    for a in mem {
+        log::trace!("{a}");
+    }
     Ok(())
 }


### PR DESCRIPTION
Now employing the Pete crate (https://crates.io/crates/pete/0.9.0), the primary distinction lies in the manner in which memory reading and writing are executed. Pete accesses the /proc/$pid/mem file of the tracee process, a method that I consider more advantageous.